### PR TITLE
Reenable fixBSLightingShaderGeometryParallaxBug for VR offset

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -101,7 +101,7 @@ namespace config
         //fixBethesdaNetCrash = ini.GetBoolean("Fixes", "BethesdaNetCrash", true);
         fixBSLightingAmbientSpecular = ini.GetBoolean("Fixes", "BSLightingAmbientSpecular", true);
         //fixBSLightingShaderForceAlphaTest = ini.GetBoolean("Fixes", "BSLightingShaderForceAlphaTest", true);
-        //fixBSLightingShaderGeometryParallaxBug = ini.GetBoolean("Fixes", "BSLightingShaderParallaxBug", true);
+        fixBSLightingShaderGeometryParallaxBug = ini.GetBoolean("Fixes", "BSLightingShaderParallaxBug", true);
         //fixBSTempEffectNiRTTI = ini.GetBoolean("Fixes", "BSTempEffectNiRTTI", true);
         fixCalendarSkipping = ini.GetBoolean("Fixes", "CalendarSkipping", true);
         fixCellInit = ini.GetBoolean("Fixes", "CellInit", true);

--- a/fixes.cpp
+++ b/fixes.cpp
@@ -28,6 +28,9 @@ namespace fixes
             PatchBSLightingAmbientSpecular();
         }
 
+        if (config::fixBSLightingShaderGeometryParallaxBug)
+            PatchBSLightingShaderSetupGeometryParallax();
+
         if (config::fixCalendarSkipping) {
             PatchCalendarSkipping();
         }

--- a/fixes/shaderfixes.cpp
+++ b/fixes/shaderfixes.cpp
@@ -9,89 +9,89 @@
 
 namespace fixes
 {
-    struct BSRenderPass
-    {
-        const static int MaxLightInArrayC = 16;
+    //struct BSRenderPass
+    //{
+    //    const static int MaxLightInArrayC = 16;
 
-        void* m_Shader;
-        void* m_Property;
-        void* m_Geometry;
-        uint32_t m_TechniqueID;
-        uint8_t Byte1C;
-        uint8_t Byte1D;  // Instance index (offset) in an instance group?
-        struct           // LOD information
-        {
-            uint8_t Index : 7;  // Also referred to as "texture degrade level"
-            bool SingleLevel : 1;
-        } m_Lod;
-        uint8_t m_LightCount;
-        uint16_t Word20;
-        BSRenderPass* m_Previous;  // Previous sub-pass
-        BSRenderPass* m_Next;      // Next sub-pass
-        void** m_SceneLights;      // Pointer to an array of 16 lights (MaxLightInArrayC, restricted to 3?)
-        uint32_t UnkDword40;       // Set from TLS variable. Pool index in BSRenderPassCache? Almost always zero.
-    };
+    //    void* m_Shader;
+    //    void* m_Property;
+    //    void* m_Geometry;
+    //    uint32_t m_TechniqueID;
+    //    uint8_t Byte1C;
+    //    uint8_t Byte1D;  // Instance index (offset) in an instance group?
+    //    struct           // LOD information
+    //    {
+    //        uint8_t Index : 7;  // Also referred to as "texture degrade level"
+    //        bool SingleLevel : 1;
+    //    } m_Lod;
+    //    uint8_t m_LightCount;
+    //    uint16_t Word20;
+    //    BSRenderPass* m_Previous;  // Previous sub-pass
+    //    BSRenderPass* m_Next;      // Next sub-pass
+    //    void** m_SceneLights;      // Pointer to an array of 16 lights (MaxLightInArrayC, restricted to 3?)
+    //    uint32_t UnkDword40;       // Set from TLS variable. Pool index in BSRenderPassCache? Almost always zero.
+    //};
 
-    typedef void (*_BSBatchRenderer_SetupAndDrawPass)(BSRenderPass* pass, uint32_t technique, bool alphaTest, uint32_t renderFlags);
-    REL::Offset<_BSBatchRenderer_SetupAndDrawPass*> BSBatchRenderer_SetupAndDrawPass_origLoc(BSBatchRenderer_SetupAndDrawPass_offset);
-    _BSBatchRenderer_SetupAndDrawPass BSBatchRenderer_SetupAndDrawPass_Orig;
+    //typedef void (*_BSBatchRenderer_SetupAndDrawPass)(BSRenderPass* pass, uint32_t technique, bool alphaTest, uint32_t renderFlags);
+    //REL::Offset<_BSBatchRenderer_SetupAndDrawPass*> BSBatchRenderer_SetupAndDrawPass_origLoc(BSBatchRenderer_SetupAndDrawPass_offset);
+    //_BSBatchRenderer_SetupAndDrawPass BSBatchRenderer_SetupAndDrawPass_Orig;
 
-    REL::Offset<std::uintptr_t> BSLightingShader_vtbl(BSLightingShader_vtbl_offset);
+    //REL::Offset<std::uintptr_t> BSLightingShader_vtbl(BSLightingShader_vtbl_offset);
 
-    uint32_t RAW_FLAG_RIM_LIGHTING = 1 << 11;
-    uint32_t RAW_FLAG_DO_ALPHA_TEST = 1 << 20;
-    uint32_t RAW_TECHNIQUE_EYE = 16;
-    uint32_t RAW_TECHNIQUE_MULTILAYERPARALLAX = 11;
-    uint32_t RAW_TECHNIQUE_ENVMAP = 1;
-    uint32_t RAW_TECHNIQUE_PARALLAX = 3;
+    //uint32_t RAW_FLAG_RIM_LIGHTING = 1 << 11;
+    //uint32_t RAW_FLAG_DO_ALPHA_TEST = 1 << 20;
+    //uint32_t RAW_TECHNIQUE_EYE = 16;
+    //uint32_t RAW_TECHNIQUE_MULTILAYERPARALLAX = 11;
+    //uint32_t RAW_TECHNIQUE_ENVMAP = 1;
+    //uint32_t RAW_TECHNIQUE_PARALLAX = 3;
 
-    void hk_BSBatchRenderer_SetupAndDrawPass(BSRenderPass* pass, uint32_t technique, bool alphaTest, uint32_t renderFlags)
-    {
-        if (*(uintptr_t*)pass->m_Shader == BSLightingShader_vtbl.GetAddress() && alphaTest)
-        {
-            auto rawTechnique = technique - 0x4800002D;
-            auto subIndex = (rawTechnique >> 24) & 0x3F;
-            if (subIndex != RAW_TECHNIQUE_EYE && subIndex != RAW_TECHNIQUE_ENVMAP && subIndex != RAW_TECHNIQUE_MULTILAYERPARALLAX && subIndex != RAW_TECHNIQUE_PARALLAX)
-            {
-                technique = technique | RAW_FLAG_DO_ALPHA_TEST;
-                pass->m_TechniqueID = technique;
-            }
-        }
+    //void hk_BSBatchRenderer_SetupAndDrawPass(BSRenderPass* pass, uint32_t technique, bool alphaTest, uint32_t renderFlags)
+    //{
+    //    if (*(uintptr_t*)pass->m_Shader == BSLightingShader_vtbl.GetAddress() && alphaTest)
+    //    {
+    //        auto rawTechnique = technique - 0x4800002D;
+    //        auto subIndex = (rawTechnique >> 24) & 0x3F;
+    //        if (subIndex != RAW_TECHNIQUE_EYE && subIndex != RAW_TECHNIQUE_ENVMAP && subIndex != RAW_TECHNIQUE_MULTILAYERPARALLAX && subIndex != RAW_TECHNIQUE_PARALLAX)
+    //        {
+    //            technique = technique | RAW_FLAG_DO_ALPHA_TEST;
+    //            pass->m_TechniqueID = technique;
+    //        }
+    //    }
 
-        BSBatchRenderer_SetupAndDrawPass_Orig(pass, technique, alphaTest, renderFlags);
-    }
+    //    BSBatchRenderer_SetupAndDrawPass_Orig(pass, technique, alphaTest, renderFlags);
+    //}
 
-    bool PatchBSLightingShaderForceAlphaTest()
-    {
-        _VMESSAGE("- BSLightingShader Force Alpha Testing -");
-        {
-            struct BSBatchRenderer_SetupAndDrawPass_Code : SKSE::CodeGenerator
-            {
-                BSBatchRenderer_SetupAndDrawPass_Code() : SKSE::CodeGenerator()
-                {
-                    // 131F810
-                    mov(ptr[rsp + 0x10], rbx);
-                    mov(ptr[rsp + 0x18], rbp);
-                    // 131F81A
+    //bool PatchBSLightingShaderForceAlphaTest()
+    //{
+    //    _VMESSAGE("- BSLightingShader Force Alpha Testing -");
+    //    {
+    //        struct BSBatchRenderer_SetupAndDrawPass_Code : SKSE::CodeGenerator
+    //        {
+    //            BSBatchRenderer_SetupAndDrawPass_Code() : SKSE::CodeGenerator()
+    //            {
+    //                // 131F810
+    //                mov(ptr[rsp + 0x10], rbx);
+    //                mov(ptr[rsp + 0x18], rbp);
+    //                // 131F81A
 
-                    // exit
-                    jmp(ptr[rip]);
-                    dq(BSBatchRenderer_SetupAndDrawPass_origLoc.GetAddress() + 0xA);
-                }
-            };
+    //                // exit
+    //                jmp(ptr[rip]);
+    //                dq(BSBatchRenderer_SetupAndDrawPass_origLoc.GetAddress() + 0xA);
+    //            }
+    //        };
 
-            BSBatchRenderer_SetupAndDrawPass_Code code;
-            code.finalize();
-            BSBatchRenderer_SetupAndDrawPass_Orig = _BSBatchRenderer_SetupAndDrawPass(code.getCode());
+    //        BSBatchRenderer_SetupAndDrawPass_Code code;
+    //        code.finalize();
+    //        BSBatchRenderer_SetupAndDrawPass_Orig = _BSBatchRenderer_SetupAndDrawPass(code.getCode());
 
-            auto trampoline = SKSE::GetTrampoline();
-            trampoline->Write6Branch(BSBatchRenderer_SetupAndDrawPass_origLoc.GetAddress(), unrestricted_cast<std::uintptr_t>(hk_BSBatchRenderer_SetupAndDrawPass));
-        }
-        _VMESSAGE("patched");
-        return true;
-    }
+    //        auto trampoline = SKSE::GetTrampoline();
+    //        trampoline->Write6Branch(BSBatchRenderer_SetupAndDrawPass_origLoc.GetAddress(), unrestricted_cast<std::uintptr_t>(hk_BSBatchRenderer_SetupAndDrawPass));
+    //    }
+    //    _VMESSAGE("patched");
+    //    return true;
+    //}
 
-    REL::Offset<uintptr_t> BSLightingShader_SetupGeometry_ParallaxFixHookLoc(offset_BSLightingShader_SetupGeometry_ParallaxTechniqueFix, 0x577);
+    REL::Offset<uintptr_t> BSLightingShader_SetupGeometry_ParallaxFixHookLoc = offset_BSLightingShader_SetupGeometry_ParallaxTechniqueFix + 0x652;
 
     bool PatchBSLightingShaderSetupGeometryParallax()
     {

--- a/include/fixes.h
+++ b/include/fixes.h
@@ -11,6 +11,7 @@ namespace fixes
     bool PatchCellInit();
     bool PatchAnimationLoadSignedCrash();
     bool PatchBSLightingAmbientSpecular();
+    bool PatchBSLightingShaderSetupGeometryParallax();
     bool PatchDoublePerkApply();
     bool PatchCalendarSkipping();
     bool PatchConjurationEnchantAbsorbs();

--- a/include/offsets.h
+++ b/include/offsets.h
@@ -110,11 +110,11 @@ constexpr REL::ID g_RequestSaveScreenshot_offset(517224);
 // Calendar Skipping
 // E8 ? ? ? ? F6 87 DC 0B 00 00 01
 constexpr REL::ID Calendar_AdvanceTime_call_offset(35402);
-
+*/
 // BSLightingShader::SetupGeometry Parallax Technique fix
 // 8B C1 25 ? ? ? ? 41 0F 45 D0
-constexpr REL::ID offset_BSLightingShader_SetupGeometry_ParallaxTechniqueFix(100565);
-
+constexpr std::uintptr_t offset_BSLightingShader_SetupGeometry_ParallaxTechniqueFix = 0x1338f60;
+/*
 // Warnings
 
 // Dupe Addon Node index


### PR DESCRIPTION
Reenable enginefixes fix for VR that is needed to enable Parallax Shader fix in VR. 
This is a WIP intended to pair with https://github.com/alandtse/SSEShaderTools/releases/tag/aers2021-05-08.

