### PR TITLE
Fix test to set updateEyePosition to true

### DIFF
--- a/EngineFixesVR.vcxproj
+++ b/EngineFixesVR.vcxproj
@@ -181,6 +181,7 @@
     <ClCompile Include="fixes.cpp" />
     <ClCompile Include="fixes\doubleperkapply.cpp" />
     <ClCompile Include="fixes\miscfixes.cpp" />
+    <ClCompile Include="fixes\shaderfixes.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="miscpatches.cpp" />
     <ClCompile Include="patches.cpp" />

--- a/EngineFixesVR.vcxproj.filters
+++ b/EngineFixesVR.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Resource Files">
@@ -59,6 +59,9 @@
     </ClCompile>
     <ClCompile Include="savedAddedSoundCategories.cpp">
       <Filter>src\patches</Filter>
+    </ClCompile>
+    <ClCompile Include="fixes\shaderfixes.cpp">
+      <Filter>src\fixes</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -5,7 +5,14 @@ Port of SSE Engine Fixes from Skyrim SE for Skyrim VR.  Go to https://www.nexusm
 
 # Build Dependencies
 - [toml++](https://marzer.github.io/tomlplusplus/index.html)
-- tbb
+- [tbb](https://github.com/oneapi-src/oneTBB)
+- [commonlibvr](https://github.com/lfrazer/CommonLibVR)
+- [sksevr](https://skse.silverlock.org/) - Include projects:
+    - common_vc14
+    - skse64
+    - skse64_common
+
+Add dependencies' `include` directory to `IncludePath` and output lib to `AdditionalLibraryDirectories`. Individual projects may be added as reference projects to EngineFixesVR so they will build first.
 
 # Current working patches:
 - Max STDIO patch
@@ -19,6 +26,7 @@ Port of SSE Engine Fixes from Skyrim SE for Skyrim VR.  Go to https://www.nexusm
 - PatchGHeapLeakDetectionCrash
 - PatchAnimationLoadSignedCrash
 - PatchBSLightingAmbientSpecular
+- PatchBSLightingShaderParallaxBug
 - PatchCalendarSkipping
 - PatchConjurationEnchantAbsorbs
 - PatchEquipShoutEventSpam
@@ -37,7 +45,7 @@ Also the "(Part 2) Engine Fixes - skse64 Preloader and TBB Lib" zip file needs t
 
 # Permissions
 
-reddit troll mod u/xMindweaverx does not have my permission to use this mod for any purpose.  He has singlehandedly destroyed the r/fo4vr subreddit and community.  
+reddit troll mod u/xMindweaverx does not have my permission to use this mod for any purpose.  He has singlehandedly destroyed the r/fo4vr subreddit and community.
 
 Please join r/fallout_VR for your fallout VR modding and support needs.
 
@@ -47,11 +55,11 @@ Most I have done here is fix offsets and update some assembly code to match the 
 
 - aers - original SSE mod author
 - Nukem -  more stuff than I can mention
-- Sniffleman/Ryan - Misc Fixes + CommonLibSSE 
+- Sniffleman/Ryan - Misc Fixes + CommonLibSSE
 - meh321 - research into tree LOD function (SSE fixes), bugfixes LE & port permissions, and for making BugFixesSSE source available so I can port it
 - sheson - skse plugin preloader for LE alongside meh
 - himika - scatter table implementation from libskyrim (LE), plus tons of research function/variable names
-- kassent - useful information from the source code of various skse plugins 
+- kassent - useful information from the source code of various skse plugins
 - Kole6738 - cosave cleaner idea+code
 - LStewieAL - Things ported from here
 

--- a/fixes/shaderfixes.cpp
+++ b/fixes/shaderfixes.cpp
@@ -9,119 +9,120 @@
 
 namespace fixes
 {
-    //struct BSRenderPass
-    //{
-    //    const static int MaxLightInArrayC = 16;
+	//struct BSRenderPass
+	//{
+	//    const static int MaxLightInArrayC = 16;
 
-    //    void* m_Shader;
-    //    void* m_Property;
-    //    void* m_Geometry;
-    //    uint32_t m_TechniqueID;
-    //    uint8_t Byte1C;
-    //    uint8_t Byte1D;  // Instance index (offset) in an instance group?
-    //    struct           // LOD information
-    //    {
-    //        uint8_t Index : 7;  // Also referred to as "texture degrade level"
-    //        bool SingleLevel : 1;
-    //    } m_Lod;
-    //    uint8_t m_LightCount;
-    //    uint16_t Word20;
-    //    BSRenderPass* m_Previous;  // Previous sub-pass
-    //    BSRenderPass* m_Next;      // Next sub-pass
-    //    void** m_SceneLights;      // Pointer to an array of 16 lights (MaxLightInArrayC, restricted to 3?)
-    //    uint32_t UnkDword40;       // Set from TLS variable. Pool index in BSRenderPassCache? Almost always zero.
-    //};
+	//    void* m_Shader;
+	//    void* m_Property;
+	//    void* m_Geometry;
+	//    uint32_t m_TechniqueID;
+	//    uint8_t Byte1C;
+	//    uint8_t Byte1D;  // Instance index (offset) in an instance group?
+	//    struct           // LOD information
+	//    {
+	//        uint8_t Index : 7;  // Also referred to as "texture degrade level"
+	//        bool SingleLevel : 1;
+	//    } m_Lod;
+	//    uint8_t m_LightCount;
+	//    uint16_t Word20;
+	//    BSRenderPass* m_Previous;  // Previous sub-pass
+	//    BSRenderPass* m_Next;      // Next sub-pass
+	//    void** m_SceneLights;      // Pointer to an array of 16 lights (MaxLightInArrayC, restricted to 3?)
+	//    uint32_t UnkDword40;       // Set from TLS variable. Pool index in BSRenderPassCache? Almost always zero.
+	//};
 
-    //typedef void (*_BSBatchRenderer_SetupAndDrawPass)(BSRenderPass* pass, uint32_t technique, bool alphaTest, uint32_t renderFlags);
-    //REL::Offset<_BSBatchRenderer_SetupAndDrawPass*> BSBatchRenderer_SetupAndDrawPass_origLoc(BSBatchRenderer_SetupAndDrawPass_offset);
-    //_BSBatchRenderer_SetupAndDrawPass BSBatchRenderer_SetupAndDrawPass_Orig;
+	//typedef void (*_BSBatchRenderer_SetupAndDrawPass)(BSRenderPass* pass, uint32_t technique, bool alphaTest, uint32_t renderFlags);
+	//REL::Offset<_BSBatchRenderer_SetupAndDrawPass*> BSBatchRenderer_SetupAndDrawPass_origLoc(BSBatchRenderer_SetupAndDrawPass_offset);
+	//_BSBatchRenderer_SetupAndDrawPass BSBatchRenderer_SetupAndDrawPass_Orig;
 
-    //REL::Offset<std::uintptr_t> BSLightingShader_vtbl(BSLightingShader_vtbl_offset);
+	//REL::Offset<std::uintptr_t> BSLightingShader_vtbl(BSLightingShader_vtbl_offset);
 
-    //uint32_t RAW_FLAG_RIM_LIGHTING = 1 << 11;
-    //uint32_t RAW_FLAG_DO_ALPHA_TEST = 1 << 20;
-    //uint32_t RAW_TECHNIQUE_EYE = 16;
-    //uint32_t RAW_TECHNIQUE_MULTILAYERPARALLAX = 11;
-    //uint32_t RAW_TECHNIQUE_ENVMAP = 1;
-    //uint32_t RAW_TECHNIQUE_PARALLAX = 3;
+	//uint32_t RAW_FLAG_RIM_LIGHTING = 1 << 11;
+	//uint32_t RAW_FLAG_DO_ALPHA_TEST = 1 << 20;
+	//uint32_t RAW_TECHNIQUE_EYE = 16;
+	//uint32_t RAW_TECHNIQUE_MULTILAYERPARALLAX = 11;
+	//uint32_t RAW_TECHNIQUE_ENVMAP = 1;
+	//uint32_t RAW_TECHNIQUE_PARALLAX = 3;
 
-    //void hk_BSBatchRenderer_SetupAndDrawPass(BSRenderPass* pass, uint32_t technique, bool alphaTest, uint32_t renderFlags)
-    //{
-    //    if (*(uintptr_t*)pass->m_Shader == BSLightingShader_vtbl.GetAddress() && alphaTest)
-    //    {
-    //        auto rawTechnique = technique - 0x4800002D;
-    //        auto subIndex = (rawTechnique >> 24) & 0x3F;
-    //        if (subIndex != RAW_TECHNIQUE_EYE && subIndex != RAW_TECHNIQUE_ENVMAP && subIndex != RAW_TECHNIQUE_MULTILAYERPARALLAX && subIndex != RAW_TECHNIQUE_PARALLAX)
-    //        {
-    //            technique = technique | RAW_FLAG_DO_ALPHA_TEST;
-    //            pass->m_TechniqueID = technique;
-    //        }
-    //    }
+	//void hk_BSBatchRenderer_SetupAndDrawPass(BSRenderPass* pass, uint32_t technique, bool alphaTest, uint32_t renderFlags)
+	//{
+	//    if (*(uintptr_t*)pass->m_Shader == BSLightingShader_vtbl.GetAddress() && alphaTest)
+	//    {
+	//        auto rawTechnique = technique - 0x4800002D;
+	//        auto subIndex = (rawTechnique >> 24) & 0x3F;
+	//        if (subIndex != RAW_TECHNIQUE_EYE && subIndex != RAW_TECHNIQUE_ENVMAP && subIndex != RAW_TECHNIQUE_MULTILAYERPARALLAX && subIndex != RAW_TECHNIQUE_PARALLAX)
+	//        {
+	//            technique = technique | RAW_FLAG_DO_ALPHA_TEST;
+	//            pass->m_TechniqueID = technique;
+	//        }
+	//    }
 
-    //    BSBatchRenderer_SetupAndDrawPass_Orig(pass, technique, alphaTest, renderFlags);
-    //}
+	//    BSBatchRenderer_SetupAndDrawPass_Orig(pass, technique, alphaTest, renderFlags);
+	//}
 
-    //bool PatchBSLightingShaderForceAlphaTest()
-    //{
-    //    _VMESSAGE("- BSLightingShader Force Alpha Testing -");
-    //    {
-    //        struct BSBatchRenderer_SetupAndDrawPass_Code : SKSE::CodeGenerator
-    //        {
-    //            BSBatchRenderer_SetupAndDrawPass_Code() : SKSE::CodeGenerator()
-    //            {
-    //                // 131F810
-    //                mov(ptr[rsp + 0x10], rbx);
-    //                mov(ptr[rsp + 0x18], rbp);
-    //                // 131F81A
+	//bool PatchBSLightingShaderForceAlphaTest()
+	//{
+	//    _VMESSAGE("- BSLightingShader Force Alpha Testing -");
+	//    {
+	//        struct BSBatchRenderer_SetupAndDrawPass_Code : SKSE::CodeGenerator
+	//        {
+	//            BSBatchRenderer_SetupAndDrawPass_Code() : SKSE::CodeGenerator()
+	//            {
+	//                // 131F810
+	//                mov(ptr[rsp + 0x10], rbx);
+	//                mov(ptr[rsp + 0x18], rbp);
+	//                // 131F81A
 
-    //                // exit
-    //                jmp(ptr[rip]);
-    //                dq(BSBatchRenderer_SetupAndDrawPass_origLoc.GetAddress() + 0xA);
-    //            }
-    //        };
+	//                // exit
+	//                jmp(ptr[rip]);
+	//                dq(BSBatchRenderer_SetupAndDrawPass_origLoc.GetAddress() + 0xA);
+	//            }
+	//        };
 
-    //        BSBatchRenderer_SetupAndDrawPass_Code code;
-    //        code.finalize();
-    //        BSBatchRenderer_SetupAndDrawPass_Orig = _BSBatchRenderer_SetupAndDrawPass(code.getCode());
+	//        BSBatchRenderer_SetupAndDrawPass_Code code;
+	//        code.finalize();
+	//        BSBatchRenderer_SetupAndDrawPass_Orig = _BSBatchRenderer_SetupAndDrawPass(code.getCode());
 
-    //        auto trampoline = SKSE::GetTrampoline();
-    //        trampoline->Write6Branch(BSBatchRenderer_SetupAndDrawPass_origLoc.GetAddress(), unrestricted_cast<std::uintptr_t>(hk_BSBatchRenderer_SetupAndDrawPass));
-    //    }
-    //    _VMESSAGE("patched");
-    //    return true;
-    //}
+	//        auto trampoline = SKSE::GetTrampoline();
+	//        trampoline->Write6Branch(BSBatchRenderer_SetupAndDrawPass_origLoc.GetAddress(), unrestricted_cast<std::uintptr_t>(hk_BSBatchRenderer_SetupAndDrawPass));
+	//    }
+	//    _VMESSAGE("patched");
+	//    return true;
+	//}
 
-    REL::Offset<uintptr_t> BSLightingShader_SetupGeometry_ParallaxFixHookLoc = offset_BSLightingShader_SetupGeometry_ParallaxTechniqueFix + 0x652;
+	REL::Offset<uintptr_t> BSLightingShader_SetupGeometry_ParallaxFixHookLoc = offset_BSLightingShader_SetupGeometry_ParallaxTechniqueFix + 0x652;
 
-    bool PatchBSLightingShaderSetupGeometryParallax()
-    {
-        _VMESSAGE("- BSLightingShader SetupGeometry - Parallax Bug -");
-        {
-            struct BSLightingShader_SetupGeometry_Parallax_Code : SKSE::CodeGenerator
-            {
-                BSLightingShader_SetupGeometry_Parallax_Code() : SKSE::CodeGenerator()
-                {
-                    // orig code
-                    and_(eax, 0x21C00);
-                    cmovnz(edx, r8d);
+	bool PatchBSLightingShaderSetupGeometryParallax()
+	{
+		_VMESSAGE("- BSLightingShader SetupGeometry - Parallax Bug -");
+		{
+			struct BSLightingShader_SetupGeometry_Parallax_Code : SKSE::CodeGenerator
+			{
+				BSLightingShader_SetupGeometry_Parallax_Code() : SKSE::CodeGenerator()
+				{
+					// orig code
+					and_(eax, 0x21C00);
+					cmovnz(edx, r8d);
 
-                    // new code
-                    cmp(ebx, 0x3);    // technique ID = PARALLAX
-                    cmovz(edx, r8d);  // set eye update true
+					// new code
+					//cmp(ebx, 0x3);    // technique ID = PARALLAX
+					and_(eax, 0x21C03);
+					cmovz(edx, r8d);  // set eye update true
 
-                    // jmp out
-                    jmp(ptr[rip]);
-                    dq(BSLightingShader_SetupGeometry_ParallaxFixHookLoc.GetAddress() + 0x9);
-                };
-            };
+					// jmp out
+					jmp(ptr[rip]);
+					dq(BSLightingShader_SetupGeometry_ParallaxFixHookLoc.GetAddress() + 0x9);
+				};
+			};
 
-            BSLightingShader_SetupGeometry_Parallax_Code code;
-            code.finalize();
+			BSLightingShader_SetupGeometry_Parallax_Code code;
+			code.finalize();
 
-            auto trampoline = SKSE::GetTrampoline();
-            trampoline->Write6Branch(BSLightingShader_SetupGeometry_ParallaxFixHookLoc.GetAddress(), uintptr_t(code.getCode()));
-        }
-        _VMESSAGE("patched");
-        return true;
-    }
+			auto trampoline = SKSE::GetTrampoline();
+			trampoline->Write6Branch(BSLightingShader_SetupGeometry_ParallaxFixHookLoc.GetAddress(), uintptr_t(code.getCode()));
+		}
+		_VMESSAGE("patched");
+		return true;
+	}
 }

--- a/fixes/shaderfixes.cpp
+++ b/fixes/shaderfixes.cpp
@@ -106,8 +106,7 @@ namespace fixes
 					cmovnz(edx, r8d);
 
 					// new code
-					//cmp(ebx, 0x3);    // technique ID = PARALLAX
-					and_(eax, 0x21C03);
+					cmp(r14d, 0x3);    // technique ID = PARALLAX
 					cmovz(edx, r8d);  // set eye update true
 
 					// jmp out
@@ -122,7 +121,7 @@ namespace fixes
 			auto trampoline = SKSE::GetTrampoline();
 			trampoline->Write6Branch(BSLightingShader_SetupGeometry_ParallaxFixHookLoc.GetAddress(), uintptr_t(code.getCode()));
 		}
-		_VMESSAGE("patched");
+		_VMESSAGE("patched %016I64X", BSLightingShader_SetupGeometry_ParallaxFixHookLoc.GetAddress());
 		return true;
 	}
 }


### PR DESCRIPTION
Adds an additional test for RAW_TECHNIQUE_PARALLAX in baseTechniqueID to set updateEyePosition. This is performed immediately after https://github.com/Nukem9/SkyrimSETest/blob/56177de9e2f65bfb8c786ae73bbcd080e6f98003/skyrim64_test/src/patches/TES/BSShader/Shaders/BSLightingShader.cpp#L881