### PR TITLE
Enable SaveGameMaxSize + set VR offsets

### DIFF
--- a/include/offsets.h
+++ b/include/offsets.h
@@ -131,18 +131,17 @@ constexpr REL::ID Call2_Unk_DataReload_func_offset(35589);
 // Refr Handle Limit
 // LookupRefrPtrByHandle uses this
 constexpr REL::ID g_RefrHandleArray_offset(514478);
-
+*/
 // Experimental
 
 // BB ? ? ? ? 4C 8B FA
-constexpr REL::ID Win32FileType_CopyToBuffer_offset(101985);
+constexpr std::uintptr_t Win32FileType_CopyToBuffer_offset = 0x137F344;
 // C6 83 ? ? ? ? ? BA ? ? ? ? ->
-constexpr REL::ID Win32FileType_ctor_offset(101962);
+constexpr std::uintptr_t Win32FileType_ctor_offset = 0x137E2CE;
 // E8 ? ? ? ? 8B D0 4C 8B CB ->
-constexpr REL::ID ScrapHeap_GetMaxSize_offset(35203);
+constexpr std::uintptr_t ScrapHeap_GetMaxSize_offset = 0x5A3064;
 
+/*
 // E8 ? ? ? ? 0F B6 D0 EB 02
 constexpr REL::ID TESFile_IsMaster_offset(13913);
-
-
 */

--- a/include/patches.h
+++ b/include/patches.h
@@ -18,7 +18,7 @@ namespace patches
     //bool PatchWaterflowAnimation();
 
     //bool PatchMemoryManager();
-    //bool PatchSaveGameMaxSize();
+    bool PatchSaveGameMaxSize();
     //bool PatchTreatAllModsAsMasters();
 
     void LoadVolumes();

--- a/miscpatches.cpp
+++ b/miscpatches.cpp
@@ -126,7 +126,19 @@ namespace patches
         return true;
     }
 
+    std::uintptr_t Win32FileType_CopyToBuffer = REL::Module::BaseAddr() + Win32FileType_CopyToBuffer_offset;
+    std::uintptr_t Win32FileType_ctor = REL::Module::BaseAddr() + Win32FileType_ctor_offset;
+    std::uintptr_t ScrapHeap_GetMaxSize = REL::Module::BaseAddr() + ScrapHeap_GetMaxSize_offset;
 
+    bool PatchSaveGameMaxSize()
+    {
+        _VMESSAGE("- save game max size -");
+        SKSE::SafeWrite8(Win32FileType_CopyToBuffer, 0x08);
+        SKSE::SafeWrite8(Win32FileType_ctor, 0x08);
+        SKSE::SafeWrite8(ScrapHeap_GetMaxSize, 0x08);
 
+        _VMESSAGE("success");
+        return true;
+    }
 
 }

--- a/patches.cpp
+++ b/patches.cpp
@@ -36,8 +36,8 @@ namespace patches
         //if (config::patchWaterflowAnimation)
         //    PatchWaterflowAnimation();
 
-        //if (config::experimentalSaveGameMaxSize)
-        //    PatchSaveGameMaxSize();
+        if (config::experimentalSaveGameMaxSize)
+            PatchSaveGameMaxSize();
 
         //if (config::experimentalTreatAllModsAsMasters)
         //    PatchTreatAllModsAsMasters();


### PR DESCRIPTION
Enables the SaveGameMaxSize experimental feature for VR, upgrading the maximum save file size from 64MB to 128MB uncompressed.

Checked with x64debug, offsets are correctly patched - but not thoroughly tested. Should work as well as it does for SSE.